### PR TITLE
Update Maven plugin versions, add support for Druid 31.0.1 and 30.0.1, remove support for 26.0.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,8 +20,9 @@ jobs:
     strategy:
       matrix:
         profile:
-          - {druid: druid-26.0.0, java: '11'}
           - {druid: druid-30.0.0, java: '17'}
+          - {druid: druid-30.0.1, java: '17'}
+          - {druid: druid-31.0.1, java: '17'}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,9 @@ on:
         required: true
         type: choice
         options:
-          - druid-26.0.0
           - druid-30.0.0
+          - druid-30.0.1
+          - druid-31.0.1
       stackable-version:
         description: 'The stackable "patch" version to use for this release (e.g., "0").'
         required: true
@@ -26,9 +27,7 @@ jobs:
       - name: Set Java Version
         id: set_java_version
         run: |
-          if [ "${{ github.event.inputs.druid-version }}" = "druid-26.0.0" ]; then
-            echo "JAVA_VERSION=11" >> "$GITHUB_ENV"
-          elif [ "${{ github.event.inputs.druid-version }}" = "druid-30.0.0" ]; then
+          if [ "${{ github.event.inputs.druid-version }}" = "druid-30.0.0" ]; then
             echo "JAVA_VERSION=17" >> "$GITHUB_ENV"
           else
             echo "JAVA_VERSION=unknown" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set Java Version
         id: set_java_version
         run: |
-          if [ "${{ github.event.inputs.druid-version }}" = "druid-30.0.0" ]; then
+          if [ "${{ github.event.inputs.druid-version }}" == "druid-30.0.0" ] || [ "${{ github.event.inputs.druid-version }}" == "druid-30.0.1" ] || [ "${{ github.event.inputs.druid-version }}" == "druid-31.0.1" ]; then
             echo "JAVA_VERSION=17" >> "$GITHUB_ENV"
           else
             echo "JAVA_VERSION=unknown" >> "$GITHUB_ENV"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@
 - Added support for Druid 30.0.0 and removed support for Druid 27.0.0 ([#104]).
 - Removed support for Druid 28.0.1 ([#105]).
 - Update dependencies ([#106]).
+- Updated Maven plugin versions, added support for Druid 31.0.1 and 30.0.1, removed support for Druid 26.0.0 ([#110]).
 
 [#104]: https://github.com/stackabletech/druid-opa-authorizer/pull/104
 [#105]: https://github.com/stackabletech/druid-opa-authorizer/pull/105
 [#106]: https://github.com/stackabletech/druid-opa-authorizer/pull/106
+[#110]: https://github.com/stackabletech/druid-opa-authorizer/pull/110
 
 ## [0.6.0] - 2024-03-19
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ An Apache Druid extension to request policy decisions from [Open Policy Agent](h
 
 This project was tested against these Druid versions:
 
-- 26.0.0
 - 30.0.0
+- 30.0.1
+- 31.0.1
 
 ## Building
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,24 +38,24 @@
     <error-prone.version>2.27.1</error-prone.version>
     <google-java-format.version>1.19.2</google-java-format.version>
 
-    <cyclonedx-maven-plugin.version>2.8.1</cyclonedx-maven-plugin.version>
+    <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
     <findsecbugs-plugin.version>1.13.0</findsecbugs-plugin.version>
-    <maven-checkstyle-plugin.version>3.5.0</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-    <maven-dependency-plugin.version>3.8.0</maven-dependency-plugin.version>
+    <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
     <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
     <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
-    <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
-    <spotbugs-maven-plugin.version>4.8.6.3</spotbugs-maven-plugin.version>
-    <spotbugs.version>4.8.5</spotbugs.version>
-    <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
-    <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
+    <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
+    <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
+    <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
+    <spotbugs.version>4.9.0</spotbugs.version>
+    <spotless-maven-plugin.version>2.44.2</spotless-maven-plugin.version>
+    <versions-maven-plugin.version>2.18.0</versions-maven-plugin.version>
   </properties>
 
   <dependencies>
@@ -159,7 +159,7 @@
             <banDuplicatePomDependencyVersions />
             <banDynamicVersions />
             <requireActiveProfile>
-              <profiles>druid-26.0.0,druid-30.0.0</profiles>
+              <profiles>druid-30.0.0,druid-30.0.1,druid-31.0.1</profiles>
               <all>false</all>
             </requireActiveProfile>
             <requireJavaVersion>
@@ -311,25 +311,6 @@
   -->
   <profiles>
     <profile>
-      <id>druid-26.0.0</id>
-      <properties>
-        <java.version>11</java.version>
-        <druid.version>26.0.0</druid.version>
-        <guava.version>16.0.1</guava.version>
-        <guice.version>4.1.0</guice.version>
-        <jackson.version>2.10.5</jackson.version>
-      </properties>
-      <dependencies>
-        <dependency>
-          <groupId>org.apache.druid</groupId>
-          <artifactId>druid-processing</artifactId>
-          <version>${druid.version}</version>
-          <scope>provided</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <!-- LTS version as of 24.7 -->
       <id>druid-30.0.0</id>
       <activation>
         <activeByDefault>true</activeByDefault>
@@ -340,6 +321,60 @@
         <guava.version>32.0.1-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <!-- jackson.version in 30.0.0 is actually specified as 2.12.7.20221012 but according to the release notes https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12#micro-patches that is "only" the BOM which specifies almost all dependencies to be 2.12.7 with the exception of jackson-databind which is at 2.12.7.1: https://repo1.maven.org/maven2/com/fasterxml/jackson/jackson-bom/2.12.7.20221012/jackson-bom-2.12.7.20221012.pom so we override that here -->
+        <jackson.version>2.12.7</jackson.version>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+          <version>2.12.7.1</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.druid</groupId>
+          <artifactId>druid-processing</artifactId>
+          <version>${druid.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>druid-30.0.1</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <java.version>17</java.version>
+        <druid.version>30.0.1</druid.version>
+        <guava.version>32.0.1-jre</guava.version>
+        <guice.version>4.1.0</guice.version>
+        <!-- jackson.version in 30.0.1 is actually specified as 2.12.7.20221012 but according to the release notes https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12#micro-patches that is "only" the BOM which specifies almost all dependencies to be 2.12.7 with the exception of jackson-databind which is at 2.12.7.1: https://repo1.maven.org/maven2/com/fasterxml/jackson/jackson-bom/2.12.7.20221012/jackson-bom-2.12.7.20221012.pom so we override that here -->
+        <jackson.version>2.12.7</jackson.version>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+          <version>2.12.7.1</version>
+          <scope>provided</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.druid</groupId>
+          <artifactId>druid-processing</artifactId>
+          <version>${druid.version}</version>
+          <scope>provided</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <!-- LTS version as of 25.3 -->
+      <id>druid-31.0.1</id>
+      <properties>
+        <java.version>17</java.version>
+        <druid.version>31.0.1</druid.version>
+        <guava.version>32.0.1-jre</guava.version>
+        <guice.version>4.1.0</guice.version>
+        <!-- jackson.version in 31.0.1 is actually specified as 2.12.7.20221012 but according to the release notes https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12#micro-patches that is "only" the BOM which specifies almost all dependencies to be 2.12.7 with the exception of jackson-databind which is at 2.12.7.1: https://repo1.maven.org/maven2/com/fasterxml/jackson/jackson-bom/2.12.7.20221012/jackson-bom-2.12.7.20221012.pom so we override that here -->
         <jackson.version>2.12.7</jackson.version>
       </properties>
       <dependencies>


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/docker-images/issues/965

Update Maven plugin versions, add support for Druid 31.0.1 and 30.0.1, remove support for 26.0.0.

Not sure about the version defined [here](https://github.com/stackabletech/druid-opa-authorizer/blob/073092a5cd5252b920c4e5450f6418fa610e33cd/pom.xml#L7), so I did not touch it.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] (Integration-)Test cases added
- [x] Documentation added or updated
- [x] Changelog updated
```

```[tasklist]
# Acceptance
- [ ] Proper release label has been added
```

