### PR TITLE
fix!: Don't activate Druid version profiles by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project was tested against these Druid versions:
 
 This repository uses Maven and requires at least Java 11 to build:
 
-        mvn --activate-profiles druid-31.0.1 clean package
+        mvn -P druid-31.0.1 clean package
 
 Please check that the Druid version you are building for is supported and adopt the profile accordingly.
 The result of this is a JAR file in the `target` directory.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ This project was tested against these Druid versions:
 
 This repository uses Maven and requires at least Java 11 to build:
 
-        mvn clean package
+        mvn --activate-profiles druid-31.0.1 clean package
 
+Please check that the Druid version you are building for is supported and adopt the profile accordingly.
 The result of this is a JAR file in the `target` directory.
 
 ## Installing

--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
     <profile>
       <id>druid-30.0.0</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
       </activation>
       <properties>
         <java.version>17</java.version>
@@ -341,7 +341,7 @@
     <profile>
       <id>druid-30.0.1</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
       </activation>
       <properties>
         <java.version>17</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -312,9 +312,6 @@
   <profiles>
     <profile>
       <id>druid-30.0.0</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
       <properties>
         <java.version>17</java.version>
         <druid.version>30.0.0</druid.version>
@@ -340,9 +337,6 @@
     </profile>
     <profile>
       <id>druid-30.0.1</id>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
       <properties>
         <java.version>17</java.version>
         <druid.version>30.0.1</druid.version>


### PR DESCRIPTION
# Description

Currently we activate multiple versions at the same time, which sounds like a bad idea.
Also, in case the user specified a non-supported version it was silently ignored and the default version was used.

## Definition of Done Checklist

- Please make sure all these things are done and tick the boxes

```[tasklist]
# Acceptance
- [ ] Proper release label has been added
```

