### PR TITLE
fix: reuse HttpClient instance across authorize() calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add support for Druid 35.0.1 ([#138]).
 - Add support for Druid 34.0.0 (deprecated) ([#134], [#138]).
 
+### Fixed
+
+- Reuse HttpClient instance across authorize() calls ([#143]).
+
 ### Removed
 
 - Remove support for Druid 33.0.0 ([#138]).
@@ -14,6 +18,7 @@
 
 [#134]: https://github.com/stackabletech/druid-opa-authorizer/pull/134
 [#138]: https://github.com/stackabletech/druid-opa-authorizer/pull/138
+[#143]: https://github.com/stackabletech/druid-opa-authorizer/pull/143
 
 ## [0.7.0] - 2025-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,6 @@
 [#61]: https://github.com/stackabletech/druid-opa-authorizer/pull/61
 [#74]: https://github.com/stackabletech/druid-opa-authorizer/pull/74
 [#75]: https://github.com/stackabletech/druid-opa-authorizer/pull/75
-[#143]: https://github.com/stackabletech/druid-opa-authorizer/pull/143
 
 ## [0.3.0] - 2022-10-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 [#61]: https://github.com/stackabletech/druid-opa-authorizer/pull/61
 [#74]: https://github.com/stackabletech/druid-opa-authorizer/pull/74
 [#75]: https://github.com/stackabletech/druid-opa-authorizer/pull/75
+[#143]: https://github.com/stackabletech/druid-opa-authorizer/pull/143
 
 ## [0.3.0] - 2022-10-13
 

--- a/src/main/java/tech/stackable/druid/opaauthorizer/OpaAuthorizer.java
+++ b/src/main/java/tech/stackable/druid/opaauthorizer/OpaAuthorizer.java
@@ -24,10 +24,12 @@ public class OpaAuthorizer implements Authorizer {
   private static final Logger LOG = new Logger(OpaAuthorizer.class);
   private final String opaUri;
   private final ObjectMapper objectMapper;
+  private final HttpClient httpClient;
 
   @JsonCreator
   public OpaAuthorizer(@JsonProperty("name") String name, @JsonProperty("opaUri") String opaUri) {
     this.opaUri = opaUri;
+    this.httpClient = HttpClient.newHttpClient();
     objectMapper =
         new ObjectMapper()
             // https://github.com/stackabletech/druid-opa-authorizer/issues/72
@@ -53,8 +55,7 @@ public class OpaAuthorizer implements Authorizer {
       return new Access(false, "Failed to create the OPA request JSON: " + e);
     }
 
-    LOG.trace("Creating HTTP Client and executing post.");
-    var client = HttpClient.newHttpClient();
+    LOG.trace("Executing OPA post.");
     try {
       var request =
           HttpRequest.newBuilder()
@@ -63,7 +64,7 @@ public class OpaAuthorizer implements Authorizer {
               .POST(HttpRequest.BodyPublishers.ofString(msgJson))
               .build();
 
-      var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+      var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
       LOG.debug("OPA Response code: %s - %s", response.statusCode(), response.body());
       LOG.trace("Parsing OPA response.");


### PR DESCRIPTION
Fixes https://github.com/stackabletech/druid-opa-authorizer/issues/142 issue

## Problem
Each call to `OpaAuthorizer.authorize()` creates a new `HttpClient` via `HttpClient.newHttpClient()`. Every `HttpClient` spawns a `SelectorManager` background thread and its own connection pool that are never shut down, causing unbounded thread growth under load.
## Fix
Move `HttpClient` to an instance field initialized once in the constructor. `HttpClient` is thread-safe and designed to be reused — a single instance handles all concurrent requests via its internal connection pool, eliminating the thread leak
