### PR TITLE
fix: Reuse HttpClient instance instead of creating one per authorize …

### DIFF
--- a/src/main/java/tech/stackable/druid/opaauthorizer/OpaAuthorizer.java
+++ b/src/main/java/tech/stackable/druid/opaauthorizer/OpaAuthorizer.java
@@ -24,10 +24,12 @@ public class OpaAuthorizer implements Authorizer {
   private static final Logger LOG = new Logger(OpaAuthorizer.class);
   private final String opaUri;
   private final ObjectMapper objectMapper;
+  private final HttpClient httpClient;
 
   @JsonCreator
   public OpaAuthorizer(@JsonProperty("name") String name, @JsonProperty("opaUri") String opaUri) {
     this.opaUri = opaUri;
+    this.httpClient = HttpClient.newHttpClient();
     objectMapper =
         new ObjectMapper()
             // https://github.com/stackabletech/druid-opa-authorizer/issues/72
@@ -53,8 +55,7 @@ public class OpaAuthorizer implements Authorizer {
       return new Access(false, "Failed to create the OPA request JSON: " + e);
     }
 
-    LOG.trace("Creating HTTP Client and executing post.");
-    var client = HttpClient.newHttpClient();
+    LOG.trace("Executing post.");
     try {
       var request =
           HttpRequest.newBuilder()
@@ -63,7 +64,7 @@ public class OpaAuthorizer implements Authorizer {
               .POST(HttpRequest.BodyPublishers.ofString(msgJson))
               .build();
 
-      var response = client.send(request, HttpResponse.BodyHandlers.ofString());
+      var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
       LOG.debug("OPA Response code: %s - %s", response.statusCode(), response.body());
       LOG.trace("Parsing OPA response.");


### PR DESCRIPTION
[Ticket](https://webflow.atlassian.net/browse/DIN-8)

**Fixes**
 https://github.com/stackabletech/druid-opa-authorizer/issues/142 issue

**Problem**
Each call to OpaAuthorizer.authorize() creates a new HttpClient via HttpClient.newHttpClient(). Every HttpClient spawns a SelectorManager background thread and its own connection pool that are never shut down, causing unbounded thread growth under load.

**Changes**
Move HttpClient to an instance field initialized once in the constructor. HttpClient is thread-safe and designed to be reused — a single instance handles all concurrent requests via its internal connection pool, eliminating the thread leak